### PR TITLE
Fix 'add user to activity' controller

### DIFF
--- a/src/controllers/activityController.js
+++ b/src/controllers/activityController.js
@@ -6,7 +6,9 @@ const getAllActivities = async (req, res) => {
   try {
     const activities = await Activity.find();
     if (activities.length === 0) {
-      res.status(StatusCodes.OK).json({ message: 'Users did not create any activity!' });
+      res
+        .status(StatusCodes.OK)
+        .json({ message: 'Users did not create any activity!' });
     } else {
       res.status(StatusCodes.OK).json({ activities, count: activities.length });
     }
@@ -20,7 +22,9 @@ const getMyActivities = async (req, res) => {
   try {
     const activities = await Activity.find({ createdBy: req.user.userId });
     if (activities.length === 0) {
-      res.status(StatusCodes.OK).json({ message: 'You did not create any activity!' });
+      res
+        .status(StatusCodes.OK)
+        .json({ message: 'You did not create any activity!' });
     } else {
       res.status(StatusCodes.OK).json({ activities, count: activities.length });
     }
@@ -36,7 +40,7 @@ const getActivity = async (req, res) => {
       params: { id: activityId },
     } = req;
     const activity = await Activity.findOne({
-      _id: activityId
+      _id: activityId,
     });
     if (!activity) {
       throw new NotFoundError(`No activity with id ${activityId}`);
@@ -176,6 +180,11 @@ const addUserToActivity = async (req, res) => {
   const { id: activityId } = req.params;
   const { userId } = req.user;
 
+  const activityWithUser = await Activity.find({ players: { $eq: userId } });
+  console.log(activityWithUser);
+  if (activityWithUser?.length !== 0) {
+    throw new BadRequestError('There is a duplicate user in the activity');
+  }
   const activity = await Activity.findByIdAndUpdate(
     activityId,
     {
@@ -183,6 +192,7 @@ const addUserToActivity = async (req, res) => {
     },
     { new: true }
   );
+
   if (!activity) {
     throw new NotFoundError(`No activity with id ${activityId}`);
   } else {


### PR DESCRIPTION
Fixed the 'add a user to activity' controller, removing the ability to add a user to an activity more than once. In such cases, an error message, 'There is a duplicate user in the activity,' should appear.