### PR TITLE
Fix 'update user' controller

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,10 +1,7 @@
 const User = require('../models/User');
 const Activity = require('../models/Activity');
 const { StatusCodes } = require('http-status-codes');
-const {
-  BadRequestError,
-  NotFoundError,
-} = require('../errors');
+const { BadRequestError, NotFoundError } = require('../errors');
 const bcrypt = require('bcrypt');
 
 const getCurrentUser = async (req, res) => {
@@ -24,11 +21,7 @@ const editUserProfile = async (req, res) => {
       email,
       experienceLevel,
       dateOfBirth,
-<<<<<<< HEAD
-      livingAddress,
-=======
       residentialAddress,
->>>>>>> main
       profileImage,
       phoneNumber,
     } = req.body;
@@ -47,35 +40,11 @@ const editUserProfile = async (req, res) => {
       lastName === '' ||
       experienceLevel === '' ||
       dateOfBirth === '' ||
-<<<<<<< HEAD
-      livingAddress === '' ||
-=======
       residentialAddress === '' ||
-      profileImage === '' ||
->>>>>>> main
       phoneNumber === ''
     ) {
       throw new BadRequestError('Fields cannot be empty');
     }
-
-<<<<<<< HEAD
-    const user = await User.findByIdAndUpdate(
-      {
-        _id: userId,
-      },
-      {
-        firstName,
-        lastName,
-        email,
-        experienceLevel,
-        dateOfBirth,
-        livingAddress,
-        profileImage,
-        phoneNumber,
-      },
-=======
-    // Hash the password if provided
-    const hashedPassword = password ? await bcrypt.hash(password, 10) : undefined;
 
     // Construct the update object based on changed fields
     const updateObject = {
@@ -87,15 +56,12 @@ const editUserProfile = async (req, res) => {
       profileImage,
       phoneNumber,
       ...(shouldUpdateEmail && { email }),
-      ...(hashedPassword && { password: hashedPassword }),
     };
 
-    const user = await User.findByIdAndUpdate(
-      { _id: userId, createdBy: userId },
-      updateObject,
->>>>>>> main
-      { new: true, runValidators: true }
-    );
+    const user = await User.findByIdAndUpdate({ _id: userId }, updateObject, {
+      new: true,
+      runValidators: true,
+    });
 
     if (!user) {
       throw new NotFoundError(`No user with id ${userId}`);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -24,10 +24,9 @@ const editUserProfile = async (req, res) => {
       firstName,
       lastName,
       email,
-      password,
       experienceLevel,
       dateOfBirth,
-      address,
+      livingAddress,
       profileImage,
       phoneNumber,
     } = req.body;
@@ -38,26 +37,23 @@ const editUserProfile = async (req, res) => {
       email === '' ||
       experienceLevel === '' ||
       dateOfBirth === '' ||
-      address === '' ||
-      profileImage === '' ||
+      livingAddress === '' ||
       phoneNumber === ''
     ) {
       throw new BadRequestError('Fields cannot be empty');
     }
-    const hashedPassword = await bcrypt.hash(password, 10);
+
     const user = await User.findByIdAndUpdate(
       {
         _id: userId,
-        createdBy: userId,
       },
       {
         firstName,
         lastName,
         email,
-        password: hashedPassword,
         experienceLevel,
         dateOfBirth,
-        address,
+        livingAddress,
         profileImage,
         phoneNumber,
       },
@@ -76,6 +72,7 @@ const editUserProfile = async (req, res) => {
     res.status(StatusCodes.BAD_REQUEST).json({ error: error.message });
   }
 };
+
 const deleteUserAccount = async (req, res) => {
   const userId = req.params.userId;
   try {

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -10,6 +10,6 @@ const {
 
 router.get('/current-user', authenticateUser, getCurrentUser);
 router.delete('/:userId', authenticateUser, deleteUserAccount);
-router.patch('/:userId', authenticateUser, editUserProfile);
+router.patch('/updateUser', authenticateUser, editUserProfile);
 
 module.exports = router;


### PR DESCRIPTION
Update user controller has been fixed:

The address field was mismatched with the schema.
The 'Update password' functionality will be on a separate page on the frontend.
createdBy has been removed.
We don't need to use UserId in the route path because we are getting the id from the auth middleware.

The 'Update user' route has been tested in Postman.